### PR TITLE
Added OpenCV git submodule to xclass/3rdParty

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "xclass/3rdParty/openal-soft"]
 	path = xclass/3rdParty/openal-soft
 	url = git://github.com/kcat/openal-soft.git
+[submodule "xclass/3rdParty/opencv"]
+	path = xclass/3rdParty/opencv
+	url = https://github.com/opencv/opencv.git

--- a/xclass/3rdParty/Makefile
+++ b/xclass/3rdParty/Makefile
@@ -11,7 +11,21 @@ all:
 	@echo making 'all' in 3rdParty
 	(cd openal-soft/build ; cmake .. ; make ; sudo make install)
 
+	# OpenCV is a bit of a monster, running cmake invokes 
+	# a lengthy download, so avoid it if it's not necessary
+	@(if [ ! -d opencv/build ] ;\
+	 then echo opencv/build NOT found ;\
+	 	mkdir opencv/build ; \
+	 	cd opencv/build ; \
+	 	cmake .. ; \
+	 else \
+		cd opencv/build ; \
+		make -j 12; \
+		sudo make install ; \
+	 fi)
+
 clean:
 	@echo making 'clean' in 3rdParty
 	@rm -rf openal-soft/build/*
+	@(if [ -d opencv/build ] ; then cd opencv/build ; make clean ; fi)
 


### PR DESCRIPTION
Adding OpenCV as a git submodule.  The 3rdParty/Makefile has a little bit of sophistication compared to the OpenAL build: it detects if cmake has already been run and won't run it again, but WILL do a "make clean" in the build directory, to rebuild the code.